### PR TITLE
fix: remove async celery task

### DIFF
--- a/arches_doorstep/pkg/extensions/etl_modules/import_single_csv_with_processing.py
+++ b/arches_doorstep/pkg/extensions/etl_modules/import_single_csv_with_processing.py
@@ -335,19 +335,19 @@ class ImportSingleCsvWithProcessing(BaseImportModule):
         csv_size = default_storage.size(csv_file_path)  # file size in byte
         use_celery_threshold = self.config.get("celeryByteSizeLimit", 500)
 
-        if self.mode != "cli" and csv_size > use_celery_threshold:
-            response = self.run_load_task_async(request, self.loadid)
-        else:
-            response = self.run_load_task(
-                self.userid,
-                self.loadid,
-                graphid,
-                has_headers,
-                fieldnames,
-                csv_mapping,
-                csv_file_name,
-                id_label,
-            )
+        # if self.mode != "cli" and csv_size > use_celery_threshold:
+        #     response = self.run_load_task_async(request, self.loadid)
+        # else:
+        response = self.run_load_task(
+            self.userid,
+            self.loadid,
+            graphid,
+            has_headers,
+            fieldnames,
+            csv_mapping,
+            csv_file_name,
+            id_label,
+        )
 
         return response
 


### PR DESCRIPTION
The worker pod is unable to read the file as there is, currently, no unified data storage.
It currently runs as a task which creates the separation between the pods. This removes the async functionality to allow the http pod read the file in the tmp dir