### PR TITLE
Feat/#31 Auto Select Node, Send back data on processing

### DIFF
--- a/arches_doorstep/pkg/extensions/etl_modules/import_single_csv_with_processing.py
+++ b/arches_doorstep/pkg/extensions/etl_modules/import_single_csv_with_processing.py
@@ -218,8 +218,8 @@ class ImportSingleCsvWithProcessing(BaseImportModule):
     
     def process(self, request):
         csvFile = request.FILES.get("file")
-        mapping = request.POST.get("mapping")
-        data = self.data_info(csvFile.read(), ["date_checker"] , mapping)
+        data_info = request.POST.get("data")
+        data = self.data_info(csvFile.read(), ["date_checker"] , data_info)
         return { 'success': True, 'data': data }
 
     def read(self, request=None, source=None):

--- a/arches_doorstep/pkg/extensions/etl_modules/import_single_csv_with_processing.py
+++ b/arches_doorstep/pkg/extensions/etl_modules/import_single_csv_with_processing.py
@@ -14,6 +14,7 @@ import os
 import uuid
 import zipfile
 import requests
+from django.forms.models import model_to_dict
 from django.contrib.auth.models import User
 from django.core.files import File
 from django.core.files.storage import default_storage
@@ -112,7 +113,12 @@ class ImportSingleCsvWithProcessing(BaseImportModule):
         filteredNodes = []
         for node in nodes:
             if is_top_nodegroup(node.nodegroup_id):
-                filteredNodes.append(node)
+                node_group_name = Node.objects.get(nodeid=node.nodegroup_id).name
+                node.nodegroup_name = node_group_name
+                node_dict = model_to_dict(node)
+                node_dict['nodegroupname'] = node_group_name
+                filteredNodes.append(node_dict)
+        
         return {"success": True, "data": filteredNodes}
 
     def get_node_lookup(self, graphid):

--- a/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
+++ b/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
@@ -490,14 +490,20 @@ onMounted(async () => {
                 </p>
             </div>
         </div>
-        <div>
-            <Button label="Auto-Select Nodes" @click="autoSelectNodes" />
-        </div>
         <div
             v-if="fileAdded && selectedResourceModel"
             class="import-single-csv-component-container"
             style="margin: 20px"
         >
+            <div>
+                <Button 
+                    label="Auto-Select Nodes" 
+                    @click="autoSelectNodes" 
+                    :disabled="!nodes"
+                    size="large" 
+                    class="btn-med"
+                />
+            </div>
             <div class="csv-mapping-table-container">
                 <table class="table table-striped csv-mapping-table">
                     <thead>
@@ -568,17 +574,19 @@ onMounted(async () => {
                     </tbody>
                 </table>
             </div>
+            <div 
+            class="margin-top" 
+            >
+                <Button 
+                    :disabled="!ready" 
+                    label="Process" 
+                    @click="process" 
+                    size="large"
+                    class="btn-large"
+                />
+            </div>
         </div>
-        <div 
-            v-if="ready"
-            class="import-single-csv-component-container" 
-        >
-            <Button 
-                :disabled="!ready" 
-                label="Process" 
-                @click="process" 
-            />
-        </div>
+        
     </div>
 </template>
 
@@ -594,6 +602,18 @@ onMounted(async () => {
 
 .space-between {
     justify-content: space-between;
+}
+
+.margin-top {
+    margin-top: 1rem;
+}
+
+.btn-med {
+    font-size: 1.2rem;
+}
+
+.btn-large {
+    font-size: 1.4rem;
 }
 
 .import-single-csv-container {

--- a/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
+++ b/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
@@ -15,6 +15,7 @@ import Accordion from 'primevue/accordion';
 import AccordionPanel from 'primevue/accordionpanel';
 import AccordionHeader from 'primevue/accordionheader';
 import AccordionContent from 'primevue/accordioncontent';  
+import ToggleButton from 'primevue/togglebutton';
 
 const state = store.state;
 const toast = useToast();
@@ -171,6 +172,7 @@ watch(columnHeaders, async (headers) => {
             return {
                 field: header,
                 node: ref(),
+                checked: ref(true),
                 language: ref(
                     arches.languages.find(
                         (lang) => lang.code == arches.activeLanguage
@@ -247,7 +249,10 @@ const filterTypes = (response, tableName, code) => {
     return null;
 };
 
-const getNodeOptions = (columnName) => {
+const getNodeOptions = (columnName, checked) => {
+    if(!checked){
+        return nodes.value
+    }
     const columnType = columnTypes.value.find(col => col?.name.replace('_', ' ') === columnName)?.type;
     let options;
     switch (columnType) {
@@ -473,13 +478,16 @@ onMounted(async () => {
                                     vertical-align: top;
                                 "
                             >
-                                <Dropdown
-                                    v-model="mapping.node"
-                                    :options=getNodeOptions(mapping.field)
-                                    option-label="name"
-                                    option-value="alias"
-                                    placeholder="Select a Node"
-                                />
+                                <div class="flex space-between">
+                                    <Dropdown
+                                        v-model="mapping.node"
+                                        :options="getNodeOptions(mapping.field, mapping.checked)"
+                                        option-label="name"
+                                        option-value="alias"
+                                        placeholder="Select a Node"
+                                    />
+                                    <ToggleButton v-model="mapping.checked" class="w-24" onLabel="filtered" offLabel="all" />
+                                </div>
                                 <Dropdown
                                     v-if="langNodes.includes(mapping.node)"
                                     v-model="mapping.language"
@@ -543,6 +551,15 @@ onMounted(async () => {
 <style>
 .p-dropdown-items-wrapper {
     max-height: 100% !important;
+}
+
+.flex {
+    display: flex;
+    align-items: center;
+}
+
+.space-between {
+    justify-content: space-between;
 }
 
 .import-single-csv-container {

--- a/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
+++ b/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
@@ -132,7 +132,7 @@ watch(csvArray, async (val) => {
 watch(selectedResourceModel, (graph) => {
     if (graph) {
         state.selectedResourceModel = graph;
-        const data = {"graphid": graph};
+        const data = {"graphid": graph.graphid};
         store.submit("get_nodes", data).then(function (response) {
             let theseNodes = response.result.map((node) => ({
                 ...node,
@@ -170,7 +170,6 @@ watch(selectedResourceModel, (graph) => {
             //     label: arches.translations.idColumnSelection,
             // });
             nodes.value = theseNodes;
-            console.log("nodes", nodes.value)
         });
     }
 });
@@ -194,7 +193,6 @@ watch(columnHeaders, async (headers) => {
 });
 
 watch(() => state.hasHeaders, async (val) => {
-    console.log("hasHeaders")
     headers.value = null;
     if (val) {
         headers.value = csvArray.value[0];
@@ -327,11 +325,16 @@ const addFile = async function (file) {
 const process = async () => {
     const data = {
         file: state.file,
-        mapping: JSON.stringify(state.fieldMapping)
+        data: JSON.stringify({ 
+            mapping: state.fieldMapping,
+            graph: {
+                id: state.selectedResourceModel.graphid,
+                name: state.selectedResourceModel.name
+            }
+        })
     };
     try {
         const response = await store.submit("process", data);
-        console.log("new response", response)
         // update store errors
         state.errorCounts = response.result.counts;
         state.totalErrors = response.result["error-count"];
@@ -356,9 +359,7 @@ const autoSelectNodes = () => {
     state.fieldMapping.forEach(mapping => {
         const closestMatch = fuzzySearch(nodes.value, mapping.field);
         if (closestMatch.length > 0) {
-            console.log("mapping", mapping)
             mapping["node"] = closestMatch[0].item.alias
-            console.log("node", closestMatch, mapping)
         }
         updateDataType(mapping, mapping.node)
     })
@@ -450,7 +451,6 @@ onMounted(async () => {
                 v-model="selectedResourceModel"
                 :options="allResourceModels"
                 option-label="name"
-                option-value="graphid"
                 placeholder="Select a Resource Model"
                 class="w-full md:w-14rem target-model-dropdown"
             />

--- a/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
+++ b/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
@@ -182,6 +182,7 @@ watch(columnHeaders, async (headers) => {
                 field: header,
                 node: ref(),
                 checked: ref(false),
+                datatype: ref(null),
                 language: ref(
                     arches.languages.find(
                         (lang) => lang.code == arches.activeLanguage
@@ -325,7 +326,8 @@ const addFile = async function (file) {
 
 const process = async () => {
     const data = {
-        file: state.file
+        file: state.file,
+        mapping: JSON.stringify(state.fieldMapping)
     };
     try {
         const response = await store.submit("process", data);
@@ -358,7 +360,15 @@ const autoSelectNodes = () => {
             mapping["node"] = closestMatch[0].item.alias
             console.log("node", closestMatch, mapping)
         }
+        updateDataType(mapping, mapping.node)
     })
+}
+
+const updateDataType = (mapping, alias) => {
+    const node = nodes.value.find(object => object.alias === alias);
+    if (node){
+        mapping.datatype = node.datatype;
+    }  
 }
 
 onMounted(async () => {
@@ -525,6 +535,7 @@ onMounted(async () => {
                                         option-label="name"
                                         option-value="alias"
                                         placeholder="Select a Node"
+                                        @update:modelValue="(alias) => updateDataType(mapping, alias)"
                                     />
                                     <ToggleButton v-model="mapping.checked" class="w-24" onLabel="filtered" offLabel="all" />
                                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+    "name": "arches-doorstep",
+    "version": "0.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "arches-doorstep",
+            "version": "0.0.1",
+            "dependencies": {
+                "fuse.js": "^7.0.0"
+            },
+            "devDependencies": {}
+        },
+        "node_modules/fuse.js": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+            "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
     "name": "arches-doorstep",
     "version": "0.0.1",
     "dependencies": {
+        "fuse.js": "^7.0.0"
     },
-    "devDependencies": {
-    },
-    "nodeModulesPaths": {
-    }
+    "nodeModulesPaths": {}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ convention = "google"
 name = "arches_doorstep"
 repository = "https://github.com/flaxandteal/arches_doorstep"
 readme = "README.md"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   {name = "Phil Weir", email = "phil.weir@flaxandteal.co.uk"},
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+fuse.js@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz"
+  integrity sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==


### PR DESCRIPTION
# Description

This PR adds the ability to auto-select the node from the graph table using fuzzy search
It applies a filter to then filter by the datatype
A button is present to allow you to switch to choose all the node options in case the data type is wrong

Added the node group name into the list to differentiate from duplicates
Added the datatype into the mapping file
Sends the mapping and graph data back to doorstep for processing

