### PR TITLE
Fix: #44 remove numerical summary

### DIFF
--- a/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
+++ b/arches_doorstep/src/arches_doorstep/etl_modules/ImportSingleCsvWithProcessing/components/ProcessingComponet.vue
@@ -49,7 +49,7 @@ const dataSummary = ref({});
 const selectedResourceModel = ref(null);
 
 const accordionValue = computed(() => {
-    return selectedResourceModel ? null : 0;
+    return selectedResourceModel.value ? "0" : null;
 });
 
 const ready = computed(() => {
@@ -460,16 +460,6 @@ onMounted(async () => {
                 <AccordionPanel value="0">
                     <AccordionHeader>Advanced Summary</AccordionHeader>
                         <AccordionContent>
-                            <div>
-                                <h4>Numerical Summary</h4>
-                                <DataTable :value="numericalSummary.rows" scrollable scroll-height="250px" class="csv-mapping-table-container summary-tables">
-                                    <Column 
-                                        v-for="heading in numericalSummary.columnHeaders" 
-                                        :key="heading" :field="heading" 
-                                        :header="heading.toUpperCase()" 
-                                    />
-                                </DataTable>
-                            </div>
                             <div>
                                 <h4>Data Summary</h4>
                                 <DataTable :value="dataSummary.rows" scrollable scroll-height="250px" class="csv-mapping-table-container summary-tables">


### PR DESCRIPTION
## Description
This removes the numerical summary table from the processing, advanced summary view.
It also fixes the issue with the advanced summary tab not opening when the model is selected.

## Test
- Upload a csv
- Select a model
- Advanced Summary should open and show a Data  Summary table only